### PR TITLE
fix bug in RPMM calculation, and round to 5 digits after point or comma 

### DIFF
--- a/reporting/basic_reporting.py
+++ b/reporting/basic_reporting.py
@@ -139,14 +139,13 @@ def compute_res_df(res_df, sequencer):
     # if sequencer == 'solid': res_df = solid_normalization(res_df)
 
     # calculating reads_per_million_ref_bases
-    res_df['reads_per_million_ref_bases'] = res_df['read_count'] / (res_df['chr_length'] / 1000000).round(2)
+    res_df['reads_per_million_ref_bases'] = res_df['read_count'] / (res_df['chr_length'] / 1000000).round(5)
 
     # calculating reads_per_million_reads_in_experiment
-    res_df['reads_per_million_reads_in_experiment'] = res_df['read_count'] / (res_df['read_count'].sum() / 1000000).round(2)
+    res_df['reads_per_million_reads_in_experiment'] = res_df['read_count'] / (res_df['read_count'].sum() / 1000000).round(5)
 
     # total normalization RPMM. Corrected
-    res_df['RPMM'] = (
-            res_df['read_count'] / (res_df['chr_length'] / 1000000) * res_df['read_count'].sum() / 1000000).round(2)
+    res_df['RPMM'] = res_df['read_count'] / ((res_df['chr_length'] / 1000000) * (res_df['read_count'].sum() / 1000000)).round(5)
 
     # calculating bacteria per human cell
     res_df = bacteria_per_human_cell(res_df)
@@ -155,9 +154,9 @@ def compute_res_df(res_df, sequencer):
 
 
 def export_res(res_df, output):
-    res_df.to_csv(f'{output}.rep.us.csv', sep=',', float_format='%.1f', index=False)
+    res_df.to_csv(f'{output}.rep.us.csv', sep=',', float_format='%.5f', index=False)
     res_df_filtered_and_sorted = res_df.loc[res_df['read_count'] >= 20].sort_values(by='RPMM', ascending=False)
-    res_df_filtered_and_sorted.to_csv(f'{output}.rep.s.csv', sep=',', float_format='%.1f', index=False)
+    res_df_filtered_and_sorted.to_csv(f'{output}.rep.s.csv', sep=',', float_format='%.5f', index=False)
 
 
 ###################################


### PR DESCRIPTION
-fixed bug in RPMM calculation, the RPMM value is now correctly calculated

-provide more accurate values for bacteria_per_human_cell, rounding off to 1 or 2 digits after point is not accurate for species with low read counts. Round off to 5 digits after point or comma